### PR TITLE
Add support for ssh remote url

### DIFF
--- a/cubyc/utils.py
+++ b/cubyc/utils.py
@@ -314,7 +314,10 @@ def get_repo_url_details(url: str) -> Tuple[Union[str, Any]]:
     tuple
         A tuple containing the domain, owner, and repository name.
     """
-    pattern = re.compile(r'https?://(?:[^@]+@)?(github|gitlab|bitbucket)\.[^/]+/([^/]+)/([^/.]+)')
+    if url.startswith('https'):
+        pattern = re.compile(r'https?://(?:[^@]+@)?(github|gitlab|bitbucket)\.[^/]+/([^/]+)/([^/.]+)')
+    else:
+        pattern = re.compile(r'^git@([^.]+)\.com:([^/]+)/([^/.]+)\.git$')
     match = pattern.match(url)
     if match:
         return match.groups()


### PR DESCRIPTION
Current implementation of `get_repo_url_details()` only supports HTTPS url:

```
>>> from cubyc.utils import get_repo_url_details
>>> url = 'https://github.com/loganthomas/cubyc-demo.git'
>>> get_repo_url_details(url)
('github', 'loganthomas', 'cubyc-demo')
>>> url = 'git@github.com:loganthomas/cubyc-demo.git'
>>> get_repo_url_details(url)
Traceback (most recent call last):
  Cell In[6], line 1
    get_repo_url_details(url)
  File ~/Desktop/repos/cubyc/cubyc/utils.py:322 in get_repo_url_details
    raise AttributeError("Invalid repository URL")
AttributeError: Invalid repository URL
```

## Proposed Change:
```
>>> from typing import Tuple, Union, Any
>>> import re
>>> def get_repo_url_details(url: str) -> Tuple[Union[str, Any]]:
...     """
...     Extracts the domain (GitHub, GitLab, Bitbucket), owner, and repository name from a
...  repository URL.
...
...     Parameters
...     ----------
...     url : str
...         The repository URL to extract details from.
...
...     Returns
...     -------
...     tuple
...         A tuple containing the domain, owner, and repository name.
...     """
...     if url.startswith('https'):
...         pattern = re.compile(r'https?://(?:[^@]+@)?(github|gitlab|bitbucket)\.[^/]+/([
... ^/]+)/([^/.]+)')
...     else:
...         pattern = re.compile(r'^git@([^.]+)\.com:([^/]+)/([^/.]+)\.git$')
...     match = pattern.match(url)
...     if match:
...         return match.groups()
...     else:
...         raise AttributeError("Invalid repository URL")
...
>>> url = 'https://github.com/loganthomas/cubyc-demo.git'
>>> get_repo_url_details(url)
('github', 'loganthomas', 'cubyc-demo')
>>> url = 'git@github.com:loganthomas/cubyc-demo.git'
>>> get_repo_url_details(url)
('github', 'loganthomas', 'cubyc-demo')
```